### PR TITLE
Fixing error with datetimes obj that includes hour of the day

### DIFF
--- a/holidays_co/__init__.py
+++ b/holidays_co/__init__.py
@@ -88,4 +88,5 @@ def is_holiday_date(d):
     if not isinstance(d, date):
         raise TypeError("Debe proporcionar un objeto tipo date")
     holiday_list = set([holiday.date for holiday in get_colombia_holidays_by_year(d.year)])
-    return d in holiday_list
+    date_obj = datetime.date(d.year, d.month, d.day)
+    return date_obj in holiday_list


### PR DESCRIPTION
If you set as parameter a datetime object that includes the hour of the day to the method `is_holiday_date`, the holiday check fails. To fix the issue, just create an object that includes only the year, month and day of the date to analyze.